### PR TITLE
Remove unnecessary use of `#[repr(packed)]`.

### DIFF
--- a/src/stemmer.rs
+++ b/src/stemmer.rs
@@ -4,7 +4,7 @@ use std::ffi::CStr;
 use std::ffi::CString;
 use std::str;
 
-#[repr(C,packed)]
+#[repr(C)]
 struct SbStemmer;
 type SbSymbol = u8;
 


### PR DESCRIPTION
This struct is laid out the same way with or without `packed`, since
it is empty.

The removal is good because there's some correctness issues with it, so
there may be breaking changes to it in future and removing it now will
avoid them all together. See
https://github.com/rust-lang/rust/issues/27060.
